### PR TITLE
Add workflow linting

### DIFF
--- a/.github/scripts/check-codeql-sarif.mjs
+++ b/.github/scripts/check-codeql-sarif.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const sarifPath = process.argv[2];
+
+if (!sarifPath) {
+  console.error("Usage: node .github/scripts/check-codeql-sarif.mjs <result.sarif>");
+  process.exit(2);
+}
+
+const sarif = JSON.parse(readFileSync(sarifPath, "utf8"));
+const findings = [];
+
+for (const run of sarif.runs ?? []) {
+  const rules = new Map((run.tool?.driver?.rules ?? []).map((rule) => [rule.id, rule]));
+
+  for (const result of run.results ?? []) {
+    const rule = rules.get(result.ruleId);
+    const level = result.level ?? rule?.defaultConfiguration?.level ?? "warning";
+    const message = result.message?.text ?? result.message?.markdown ?? "";
+    const location = result.locations?.[0]?.physicalLocation;
+    const uri = location?.artifactLocation?.uri ?? "unknown";
+    const line = location?.region?.startLine ?? 1;
+
+    findings.push({
+      level,
+      line,
+      message,
+      ruleId: result.ruleId ?? "unknown",
+      uri,
+    });
+  }
+}
+
+if (findings.length > 0) {
+  console.error(`CodeQL produced ${findings.length} finding(s).`);
+  for (const finding of findings) {
+    console.error(
+      `- ${finding.level} ${finding.ruleId} ${finding.uri}:${finding.line} ${finding.message}`
+    );
+  }
+  process.exit(1);
+}
+
+console.log("No CodeQL findings.");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,23 +3,30 @@ name: CI
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
+
+      - name: Enable Corepack
+        run: corepack enable
+        shell: bash
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -37,7 +44,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -62,7 +69,7 @@ jobs:
         run: pnpm exec prettier --check .
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: "pnpm"
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.1
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,26 +7,29 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: "pnpm"
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
+
+      - name: Enable Corepack
+        run: corepack enable
+        shell: bash
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -43,12 +46,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/**
-          generate_release_notes: true
-          draft: false
-          prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh release create "${GITHUB_REF_NAME}" dist/** --generate-notes
+        shell: bash

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,184 @@
+name: workflow-lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/ghalint.y*ml"
+      - ".github/zizmor.y*ml"
+      - ".pinact.y*ml"
+      - "zizmor.y*ml"
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download pinact
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/pinact
+          PINACT_VERSION: v4.1.0
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          archive="pinact_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o "/tmp/${archive}" "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/${archive}"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/pinact_checksums.txt "https://github.com/suzuki-shunsuke/pinact/releases/download/${PINACT_VERSION}/pinact_${PINACT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  ${archive}$" pinact_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp
+          sudo install -m 0755 /tmp/pinact /usr/local/bin/pinact
+          pinact version
+        shell: bash
+
+      - name: Check pinned action refs
+        run: pinact run --check
+        shell: bash
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        id: get_actionlint
+        env:
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          ACTIONLINT_VERSION: v1.7.12
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/download-actionlint.bash "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash"
+          bash /tmp/download-actionlint.bash "${ACTIONLINT_VERSION#v}"
+        shell: bash
+
+      - name: Check workflow files
+        env:
+          ACTIONLINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+        run: |
+          "${ACTIONLINT_EXECUTABLE}" -color
+        shell: bash
+
+  ghalint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download ghalint
+        env:
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/ghalint
+          GHALINT_VERSION: v1.5.6
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          archive="ghalint_${GHALINT_VERSION#v}_linux_amd64.tar.gz"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o "/tmp/${archive}" "https://github.com/suzuki-shunsuke/ghalint/releases/download/${GHALINT_VERSION}/${archive}"
+          curl -sSfL -H "Authorization: token ${GITHUB_TOKEN}" -o /tmp/ghalint_checksums.txt "https://github.com/suzuki-shunsuke/ghalint/releases/download/${GHALINT_VERSION}/ghalint_${GHALINT_VERSION#v}_checksums.txt"
+          (cd /tmp && grep "  ${archive}$" ghalint_checksums.txt | sha256sum -c -)
+          tar -xzf "/tmp/${archive}" -C /tmp
+          sudo install -m 0755 /tmp/ghalint /usr/local/bin/ghalint
+          ghalint version
+        shell: bash
+
+      - name: Check workflow files
+        run: ghalint run
+        shell: bash
+
+      - name: Run ghalint for composite actions
+        run: ghalint run-action
+        shell: bash
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor security check
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github/workflows/
+          min-severity: medium
+          token: ${{ github.token }}
+          advanced-security: false
+          annotations: true
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.25.2
+
+  codeql-actions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        with:
+          languages: actions
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        id: analyze
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        with:
+          category: /language:actions
+          output: ../results
+          upload: never
+          upload-database: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Check CodeQL findings
+        env:
+          SARIF_DIR: ${{ steps.analyze.outputs.sarif-output }}
+        run: |
+          set -euo pipefail
+
+          sarif_file="$(find "${SARIF_DIR}" -name "*.sarif" -print -quit)"
+          if [[ -z "${sarif_file}" ]]; then
+            echo "No CodeQL SARIF file was generated." >&2
+            exit 1
+          fi
+
+          node .github/scripts/check-codeql-sarif.mjs "${sarif_file}"
+        shell: bash

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+min_age:
+  value: 7
+  always: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,48 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:best-practices", "group:definitelyTyped"],
+  minimumReleaseAge: "7 days",
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s",
+      ],
+    },
+  ],
+  packageRules: [
+    {
+      description: "Automerge minor, patch, and pin updates for production npm dependencies after a 7 day minimum release age",
+      groupName: "dependencies (non-major)",
+      matchManagers: ["npm"],
+      matchDepTypes: ["dependencies"],
+      matchUpdateTypes: ["minor", "patch", "pin"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+    {
+      description: "Automerge minor, patch, and pin updates for development npm dependencies after a 7 day minimum release age",
+      groupName: "devDependencies (non-major)",
+      matchManagers: ["npm"],
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch", "pin"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+    {
+      description: "Automerge minor, patch, digest, and pinDigest GitHub Actions updates after a 7 day minimum release age",
+      groupName: "github-actions (non-major)",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "digest", "pinDigest"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
- add workflow-lint with pinact, actionlint, ghalint, zizmor, and CodeQL Actions
- pin workflow actions and reduce release workflow third-party actions
- add Renovate configuration for dependency and workflow tool updates

## Checks
- PINACT_GITHUB_TOKEN=... pinact run --check
- actionlint -color
- ghalint run
- ghalint run-action
- uvx zizmor .github/workflows --min-severity medium
- renovate-config-validator renovate.json5
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run typecheck
- pnpm test
- pnpm run test:coverage
- pnpm run build
- pnpm exec prettier --check .